### PR TITLE
Fix Jina embedding model loading on current dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,9 @@ vscode-extension/out/
 vscode-extension/*.vsix
 
 temp_check/
+
+# Rust build output
+codexa-core/target/
+
+# Local project metadata
+.codexaignore

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,13 +60,15 @@ dependencies = [
 
 [project.optional-dependencies]
 ml = [
-    "sentence-transformers>=2.2.0",
+    "sentence-transformers>=2.2.0,<6",
+    "transformers>=4.41.0,<5",
     "faiss-cpu>=1.7.4",
 ]
 dev = [
     "pytest>=7.4.0",
     "pytest-cov>=4.1.0",
-    "sentence-transformers>=2.2.0",
+    "sentence-transformers>=2.2.0,<6",
+    "transformers>=4.41.0,<5",
     "faiss-cpu>=1.7.4",
 ]
 tui = [

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,8 @@ pydantic>=2.0.0
 rich>=13.0.0
 
 # Embeddings & Search
-sentence-transformers>=2.2.0
+sentence-transformers>=2.2.0,<6
+transformers>=4.41.0,<5
 faiss-cpu>=1.7.4
 
 # Code Parsing

--- a/semantic_code_intelligence/embeddings/generator.py
+++ b/semantic_code_intelligence/embeddings/generator.py
@@ -28,6 +28,7 @@ logger = get_logger("embeddings")
 _model_cache: dict[str, "SentenceTransformer"] = {}
 BYTES_PER_GB = 1024 ** 3
 _MIN_TORCH_RAM_BYTES = 2 * BYTES_PER_GB
+_JINA_CODE_MODEL = "jinaai/jina-embeddings-v2-base-code"
 
 
 def _configure_hf_token() -> None:
@@ -263,6 +264,9 @@ def get_model(
         load_kwargs: dict[str, Any] = {}
         if local_only:
             load_kwargs["local_files_only"] = True
+        if not use_onnx and model_name == _JINA_CODE_MODEL:
+            load_kwargs["model_kwargs"] = {"attn_implementation": "eager"}
+            load_kwargs["trust_remote_code"] = True
 
         if use_onnx:
             try:
@@ -278,7 +282,7 @@ def get_model(
             if local_only:
                 # Cache may be corrupted — retry with network access
                 logger.warning("Local cache load failed; re-downloading model.")
-                _model_cache[cache_key] = SentenceTransformer(model_name)
+                _model_cache[cache_key] = SentenceTransformer(model_name, **load_kwargs)
             else:
                 raise
         except RuntimeError as exc:

--- a/semantic_code_intelligence/mcp/__init__.py
+++ b/semantic_code_intelligence/mcp/__init__.py
@@ -22,13 +22,15 @@ from typing import Any
 try:
     from mcp.server import Server
     from mcp.server.stdio import stdio_server
-    from mcp.types import TextContent, Tool
+    from mcp.types import CallToolResult, ListToolsResult, TextContent, Tool
     _HAS_MCP = True
 except ImportError:  # mcp SDK not installed (e.g. Python 3.13)
     _HAS_MCP = False
     Server = None  # type: ignore[assignment,misc]
     TextContent = None  # type: ignore[assignment,misc]
     Tool = None  # type: ignore[assignment,misc]
+    CallToolResult = None  # type: ignore[assignment,misc]
+    ListToolsResult = None  # type: ignore[assignment,misc]
 
 from semantic_code_intelligence.config.settings import AppConfig
 from semantic_code_intelligence.utils.logging import get_logger
@@ -379,13 +381,7 @@ def _create_server(project_root: Path) -> "Server":
     """Create and configure an MCP ``Server`` with all CodexA tools."""
     if not _HAS_MCP:
         raise RuntimeError("The 'mcp' package is required but not installed.")
-    server = Server("codexa-mcp")
 
-    @server.list_tools()
-    async def handle_list_tools() -> list:
-        return MCP_TOOLS
-
-    @server.call_tool()
     async def handle_call_tool(name: str, arguments: dict | None) -> list:
         args = arguments or {}
         try:
@@ -393,6 +389,30 @@ def _create_server(project_root: Path) -> "Server":
             return [TextContent(type="text", text=json.dumps(result, indent=2))]
         except Exception as e:
             return [TextContent(type="text", text=f"Error: {e}")]
+
+    if hasattr(Server, "list_tools"):
+        server = Server("codexa-mcp")
+
+        @server.list_tools()
+        async def handle_list_tools() -> list:
+            return MCP_TOOLS
+
+        @server.call_tool()
+        async def handle_call_tool_legacy(name: str, arguments: dict | None) -> list:
+            return await handle_call_tool(name, arguments)
+    else:
+        async def handle_list_tools_modern(_context: Any, _params: Any) -> ListToolsResult:
+            return ListToolsResult(tools=MCP_TOOLS)
+
+        async def handle_call_tool_modern(_context: Any, params: Any) -> CallToolResult:
+            content = await handle_call_tool(params.name, params.arguments)
+            return CallToolResult(content=content)
+
+        server = Server(
+            "codexa-mcp",
+            on_list_tools=handle_list_tools_modern,
+            on_call_tool=handle_call_tool_modern,
+        )
 
     return server
 

--- a/semantic_code_intelligence/tests/test_embeddings.py
+++ b/semantic_code_intelligence/tests/test_embeddings.py
@@ -2,10 +2,14 @@
 
 from __future__ import annotations
 
+import sys
+from types import SimpleNamespace
+
 import numpy as np
 import pytest
 
 from semantic_code_intelligence.embeddings.generator import (
+    _model_cache,
     generate_embeddings,
     get_embedding_dimension,
     get_model,
@@ -14,6 +18,42 @@ from semantic_code_intelligence.embeddings.generator import (
 
 class TestGetModel:
     """Tests for model loading."""
+
+    def test_jina_model_uses_supported_attention_implementation(self, monkeypatch: pytest.MonkeyPatch):
+        calls: list[dict] = []
+
+        class FakeSentenceTransformer:
+            def __init__(self, model_name: str, **kwargs):
+                calls.append({"model_name": model_name, **kwargs})
+
+        monkeypatch.setitem(
+            sys.modules,
+            "sentence_transformers",
+            SimpleNamespace(SentenceTransformer=FakeSentenceTransformer),
+        )
+        monkeypatch.setattr(
+            "semantic_code_intelligence.embeddings.generator._model_cached_locally",
+            lambda model_name: False,
+        )
+        monkeypatch.setattr(
+            "semantic_code_intelligence.embeddings.generator._show_download_banner",
+            lambda model_name: None,
+        )
+        monkeypatch.setattr(
+            "semantic_code_intelligence.embeddings.generator._onnx_available",
+            lambda: False,
+        )
+        _model_cache.clear()
+
+        get_model("jinaai/jina-embeddings-v2-base-code", backend="torch")
+
+        assert calls == [
+            {
+                "model_name": "jinaai/jina-embeddings-v2-base-code",
+                "model_kwargs": {"attn_implementation": "eager"},
+                "trust_remote_code": True,
+            }
+        ]
 
     def test_loads_model(self):
         model = get_model("all-MiniLM-L6-v2")


### PR DESCRIPTION
## Summary
- use supported eager attention for the Jina code embedding model
- enable Jina's remote Transformers implementation
- constrain sentence-transformers and Transformers to compatible major versions
- support current and legacy MCP server handler APIs
- ignore generated Rust and local CodexA artifacts

## Validation
- `2670 passed, 7 warnings`

Closes #17