### PR TITLE
fix(safety): exclude PDO method calls from exec() false-positive detection

### DIFF
--- a/semantic_code_intelligence/llm/safety.py
+++ b/semantic_code_intelligence/llm/safety.py
@@ -23,7 +23,7 @@ _DANGEROUS_PATTERNS: list[tuple[str, str]] = [
     (r"\brm\s+-rf\s+/", "Destructive rm -rf / command"),
     # Dynamic code execution
     (r"\beval\s*\(", "eval() call — avoid dynamic code execution"),
-    (r"\bexec\s*\(", "exec() call — avoid dynamic code execution"),
+    (r"(?<!->)(?<!::)\bexec\s*\(", "exec() call — avoid dynamic code execution"),
     (r"\b__import__\s*\(", "Dynamic __import__() — use explicit imports"),
     # SQL injection risk
     (r"DROP\s+TABLE|DROP\s+DATABASE", "SQL DROP statement — potential data loss"),

--- a/semantic_code_intelligence/tests/test_phase12.py
+++ b/semantic_code_intelligence/tests/test_phase12.py
@@ -265,6 +265,37 @@ config = Path("config.yaml").read_text()
         assert any("XSS" in d for d in descs)
         assert any("MD5" in d for d in descs)
 
+    # --- Issue #19: PDO::exec() false-positive regression tests ---
+
+    def test_exec_global_still_flagged(self):
+        """Standalone exec() (global PHP / Python function) must still be caught."""
+        assert not self.validator.is_safe("exec('ls -la')")
+
+    def test_exec_global_python_still_flagged(self):
+        """Python exec() with dynamic code must still be caught."""
+        assert not self.validator.is_safe("exec(user_code)")
+
+    def test_pdo_arrow_exec_not_flagged(self):
+        """PHP $pdo->exec() is a PDO method call and must NOT be flagged."""
+        assert self.validator.is_safe("$pdo->exec('CREATE TABLE foo (id INT)')")
+
+    def test_connection_arrow_exec_not_flagged(self):
+        """PHP $connection->exec() is a PDO method call and must NOT be flagged."""
+        assert self.validator.is_safe("$connection->exec($sql)")
+
+    def test_pdo_static_exec_not_flagged(self):
+        """PHP PDO::exec() static call must NOT be flagged."""
+        assert self.validator.is_safe("PDO::exec($statement)")
+
+    def test_pdo_exec_multiline_not_flagged(self):
+        """Multi-line PHP code using PDO method calls should pass the safety check."""
+        php_code = (
+            "$pdo = new PDO($dsn, $user, $pass);\n"
+            "$pdo->exec('SET NAMES utf8mb4');\n"
+            "$connection->exec($migrationSql);\n"
+        )
+        assert self.validator.is_safe(php_code)
+
 
 # =========================================================================
 # VSCode streaming context tests


### PR DESCRIPTION
## Summary

Fixes #19

The PHP safety scanner was reporting **false positives** for legitimate PDO method calls like `$pdo->exec()` and `PDO::exec()`, flagging them as _dynamic code execution_ findings.

## Root Cause

The `exec()` danger pattern in `_DANGEROUS_PATTERNS` used a simple word-boundary regex:
```python
(r"\bexec\s*\(", "exec() call — avoid dynamic code execution")
```

This matched **any** occurrence of `exec(` in a line — including PHP object method calls like `$connection->exec($sql)` — because it did not distinguish between the global function and method-call syntax.

## Fix

Added **negative lookbehinds** for `->` and `::` operators so only standalone function invocations are flagged:

```python
(r"(?<!->)(?<!::)\bexec\s*\(", "exec() call — avoid dynamic code execution")
```

| Pattern | Before | After |
|---|---|---|
| `exec('cmd')` | ⛔ flagged | ⛔ flagged (correct) |
| `exec(user_code)` | ⛔ flagged | ⛔ flagged (correct) |
| `$pdo->exec($sql)` | ❌ false positive | ✅ allowed |
| `$connection->exec($sql)` | ❌ false positive | ✅ allowed |
| `PDO::exec($stmt)` | ❌ false positive | ✅ allowed |

## Changes

- **`semantic_code_intelligence/llm/safety.py`** — updated the `exec()` regex pattern
- **`semantic_code_intelligence/tests/test_phase12.py`** — added 6 regression tests