### PR TITLE
fix(safety): exclude PDO method calls from exec() false-positive detection

### DIFF
--- a/semantic_code_intelligence/llm/safety.py
+++ b/semantic_code_intelligence/llm/safety.py
@@ -23,6 +23,10 @@ _DANGEROUS_PATTERNS: list[tuple[str, str]] = [
     (r"\brm\s+-rf\s+/", "Destructive rm -rf / command"),
     # Dynamic code execution
     (r"\beval\s*\(", "eval() call — avoid dynamic code execution"),
+    # Negative lookbehinds exclude OOP/PHP method calls (e.g. $pdo->exec(),
+    # PDO::exec()).  Whitespace normalisation in SafetyValidator.validate()
+    # ensures spaced forms ($pdo -> exec(), SomeClass :: exec()) are also
+    # excluded before these patterns are applied.
     (r"(?<!->)(?<!::)\bexec\s*\(", "exec() call — avoid dynamic code execution"),
     (r"\b__import__\s*\(", "Dynamic __import__() — use explicit imports"),
     # SQL injection risk
@@ -73,6 +77,14 @@ class SafetyReport:
         }
 
 
+# Regex used to collapse optional whitespace around PHP/OOP method-call
+# operators before safety patterns are applied.  This ensures that both the
+# compact form  ($pdo->exec())  and the spaced form  ($pdo -> exec())  are
+# normalised to the same token sequence, allowing the fixed-width
+# lookbehinds in _DANGEROUS_PATTERNS to work correctly in all cases.
+_PHP_OPERATOR_WS = re.compile(r"\s*(->|::)\s*")
+
+
 class SafetyValidator:
     """Validates LLM-generated code for known dangerous patterns."""
 
@@ -85,11 +97,22 @@ class SafetyValidator:
         """Scan ``code`` for dangerous patterns.
 
         Returns a SafetyReport. If any issues are found, ``safe`` is False.
+
+        Each source line is normalised before matching: whitespace surrounding
+        OOP/PHP method-call operators (``->`` and ``::``) is collapsed so that
+        both compact forms (``$pdo->exec()``) and spaced forms
+        (``$pdo -> exec()``) are treated identically by the lookbehind
+        assertions in the pattern list.
         """
         issues: list[SafetyIssue] = []
         for line_no, line in enumerate(code.splitlines(), start=1):
+            # Normalise  "-> "  and  ":: "  (with any surrounding whitespace)
+            # to the compact forms  "->"  and  "::"  so that the fixed-width
+            # negative lookbehinds  (?<!->)  and  (?<!::)  fire correctly even
+            # when the source code uses spaces around these operators.
+            normalised = _PHP_OPERATOR_WS.sub(r"\1", line)
             for pattern, description in self._patterns:
-                if re.search(pattern, line, re.IGNORECASE):
+                if re.search(pattern, normalised, re.IGNORECASE):
                     issues.append(
                         SafetyIssue(
                             pattern=pattern,

--- a/semantic_code_intelligence/llm/safety.py
+++ b/semantic_code_intelligence/llm/safety.py
@@ -23,7 +23,7 @@ _DANGEROUS_PATTERNS: list[tuple[str, str]] = [
     (r"\brm\s+-rf\s+/", "Destructive rm -rf / command"),
     # Dynamic code execution
     (r"\beval\s*\(", "eval() call — avoid dynamic code execution"),
-    (r"\bexec\s*\(", "exec() call — avoid dynamic code execution"),
+    (r"(?<!->)(?<!::)\bexec\s*\(", "exec() call — avoid dynamic code execution"),
     (r"\b__import__\s*\(", "Dynamic __import__() — use explicit imports"),
     # SQL injection risk
     (r"DROP\s+TABLE|DROP\s+DATABASE", "SQL DROP statement — potential data loss"),

--- a/semantic_code_intelligence/tests/test_phase12.py
+++ b/semantic_code_intelligence/tests/test_phase12.py
@@ -265,6 +265,37 @@ config = Path("config.yaml").read_text()
         assert any("XSS" in d for d in descs)
         assert any("MD5" in d for d in descs)
 
+    # --- Issue #19: PDO::exec() false-positive regression tests ---
+
+    def test_exec_global_still_flagged(self):
+        """Standalone exec() (global PHP / Python function) must still be caught."""
+        assert not self.validator.is_safe("exec('ls -la')")
+
+    def test_exec_global_python_still_flagged(self):
+        """Python exec() with dynamic code must still be caught."""
+        assert not self.validator.is_safe("exec(user_code)")
+
+    def test_pdo_arrow_exec_not_flagged(self):
+        """PHP $pdo->exec() is a PDO method call and must NOT be flagged."""
+        assert self.validator.is_safe("$pdo->exec('CREATE TABLE foo (id INT)')")
+
+    def test_connection_arrow_exec_not_flagged(self):
+        """PHP $connection->exec() is a PDO method call and must NOT be flagged."""
+        assert self.validator.is_safe("$connection->exec($sql)")
+
+    def test_pdo_static_exec_not_flagged(self):
+        """PHP PDO::exec() static call must NOT be flagged."""
+        assert self.validator.is_safe("PDO::exec($statement)")
+
+    def test_pdo_exec_multiline_not_flagged(self):
+        """Multi-line PHP code using PDO method calls should pass the safety check."""
+        php_code = (
+            "$pdo = new PDO($dsn, $user, $pass);\n"
+            "$pdo->exec('SET NAMES utf8mb4');\n"
+            "$connection->exec($migrationSql);\n"
+        )
+        assert self.validator.is_safe(php_code)
+
 
 # =========================================================================
 # VSCode streaming context tests

--- a/semantic_code_intelligence/tests/test_phase12.py
+++ b/semantic_code_intelligence/tests/test_phase12.py
@@ -296,6 +296,31 @@ config = Path("config.yaml").read_text()
         )
         assert self.validator.is_safe(php_code)
 
+    # Whitespace-spaced forms — regression tests added per M9nx review feedback.
+    # PHP permits spaces around -> and :: so "$pdo -> exec($sql)" and
+    # "SomeClass :: exec($sql)" must also be treated as method calls, not
+    # flagged as dynamic code execution.
+
+    def test_pdo_arrow_spaced_exec_not_flagged(self):
+        """PHP $pdo -> exec() with spaces around -> must NOT be flagged."""
+        assert self.validator.is_safe("$pdo -> exec($sql)")
+
+    def test_connection_arrow_spaced_exec_not_flagged(self):
+        """PHP $connection -> exec() with spaces around -> must NOT be flagged."""
+        assert self.validator.is_safe("$connection -> exec($migrationSql)")
+
+    def test_static_double_colon_spaced_exec_not_flagged(self):
+        """PHP SomeClass :: exec() with spaces around :: must NOT be flagged."""
+        assert self.validator.is_safe("SomeClass :: exec($statement)")
+
+    def test_pdo_static_spaced_exec_not_flagged(self):
+        """PHP PDO :: exec() with spaces around :: must NOT be flagged."""
+        assert self.validator.is_safe("PDO :: exec($stmt)")
+
+    def test_exec_global_still_flagged_after_normalisation(self):
+        """Bare exec() must still be caught even after whitespace normalisation."""
+        assert not self.validator.is_safe("result = exec(user_input)")
+
 
 # =========================================================================
 # VSCode streaming context tests


### PR DESCRIPTION
## Summary

Fixes #19

The PHP safety scanner was reporting **false positives** for legitimate PDO method calls like `$pdo->exec()` and `PDO::exec()`, flagging them as _dynamic code execution_ findings.

## Root Cause

The `exec()` danger pattern used a simple word-boundary regex:
```python
(r"\bexec\s*\(", "exec() call — avoid dynamic code execution")
```
This matched **any** `exec(` — including PHP PDO method calls like `$connection->exec($sql)`.

## Fix

Added **negative lookbehinds** for `->` and `::` so only standalone function calls are flagged:
```python
(r"(?<!->)(?<!::)\bexec\s*\(", "exec() call — avoid dynamic code execution")
```

| Pattern | Before | After |
|---|---|---|
| `exec('cmd')` | ⛔ flagged | ⛔ flagged (correct) |
| `exec(user_code)` | ⛔ flagged | ⛔ flagged (correct) |
| `$pdo->exec($sql)` | ❌ false positive | ✅ allowed |
| `$connection->exec($sql)` | ❌ false positive | ✅ allowed |
| `PDO::exec($stmt)` | ❌ false positive | ✅ allowed |

## Files Changed
- `semantic_code_intelligence/llm/safety.py` — 1-line regex fix
- `semantic_code_intelligence/tests/test_phase12.py` — 6 regression tests